### PR TITLE
Fix typos in notification message, docs and comments

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,9 +12,9 @@
 
 ## "Official" Releases
 
-This app is available throught the
+This app is available through the
 [Nextcloud app-store](https://apps.nextcloud.com/apps/files_archive)
-and show up automatically in the app-installation option of you
+and shows up automatically in the app-installation option of your
 Nextcloud instance if you are logged in as administrator. The goal is
 to have working versions for the most recent three (3) releases of
 nextcloud available through the Nextcloud app-store.
@@ -79,7 +79,7 @@ So:
     - **pull request to improve this part of the documentation are very welcome**
 - build the app with
   - `make build` to generate a production version of the app
-  - `make dev` to generate a development version debuging info
+  - `make dev` to generate a development version with debugging info
     compiled in. This mostly affects the generated JavaScript assets.
   - in case you run `make` repeatedly (perhaps after adjusting things
     to your liking) and it fails: try to run `make realclean` in order

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ archive file as "external" mount into the current directory. This
 mount is "movable" and can be renamed or moved into another folder.
 
 The app further adds an entry to the details-view in the right
-side-bar wheren archive information is displayed, and controls for
-mounting and extracing the archive to any location in the cloud
+side-bar where archive information is displayed, and controls for
+mounting and extracting the archive to any location in the cloud
 file-system are available.
 
 ## Details
@@ -125,7 +125,7 @@ supported. There are some caveats, however:
 - Unfortunately, the Nextcloud CRON-jobs need to have access to the
   file-space as they periodically scan the file-system. However, the
   cron-jobs run unauthenticated. In order to make this work, the
-  archvie passwords for the active mounts are stored in the app's
+  archive passwords for the active mounts are stored in the app's
   database table. The passwords are encrypted with the server
   password. However, that is stored in plain-text in the `config.php`
   of the Nextcloud instance running on the server.

--- a/lib/BackgroundJob/ArchiveJob.php
+++ b/lib/BackgroundJob/ArchiveJob.php
@@ -233,9 +233,9 @@ class ArchiveJob extends QueuedJob
       $archivePassPhrase = $this->getArchivePassphrase();
       $stripCommonPathPrefix = $this->getStripCommonPathPrefix();
 
-      // @todo The use of controller classes at this point is abuse, their
+      // @todo The use of controller classes at this point is abuse, there
       // should be common service classes providing the required functionality
-      // which are then shared by the backgroun job and the frontend
+      // which are then shared by the background job and the frontend
       // controller classes.
       switch ($this->getTarget()) {
         case self::TARGET_MOUNT:

--- a/lib/Exceptions/Exception.php
+++ b/lib/Exceptions/Exception.php
@@ -23,7 +23,7 @@
 namespace OCA\FilesArchive\Exceptions;
 
 /**
- * Exception class abstaction.
+ * Exception class abstraction.
  */
 class Exception extends \Exception
 {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -219,7 +219,7 @@ class Notifier implements INotifier
           if ($subjectType & self::TYPE_MOUNT) {
             $subjectTemplate = $l->t('Mounting {source} at {destination} has failed.');
           } else {
-            $subjectTemplate = $l->t('Extacting {source} to {destination} bas failed.');
+            $subjectTemplate = $l->t('Extracting {source} to {destination} has failed.');
           }
         }
         break;


### PR DESCRIPTION
During the translation I found a string with a typo. Today, before I committed I tried to have Claude Code search for and correct other typos.