### PR TITLE
Build and publish the app tarball on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build the ready-to-use app archive (the same artifact as `make appstore`)
+# and attach it to the GitHub release whenever a `v*` tag is pushed. The
+# job can also be triggered manually (workflow_dispatch) to test the build
+# without creating a tag; in that case the tarball is only kept as a
+# workflow artifact and not attached to any release.
+name: Build release tarball
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # dev-scripts/MakeHelp is a git submodule required by the Makefile.
+          submodules: recursive
+
+      - name: Install xpath
+        # dev-scripts/lib/makefile/setup.mk needs the xpath binary to parse
+        # the app name and the supported cloud versions out of
+        # appinfo/info.xml; its fallback path only works inside a server tree.
+        run: sudo apt-get install -y libxml-xpath-perl
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Read app version
+        id: meta
+        run: |
+          version=$(php -r 'echo (string)simplexml_load_file("appinfo/info.xml")->version;')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build app archive
+        # APP_VERSION is not derived from info.xml by the Makefile, so pass it
+        # explicitly to get it embedded into the generated app-config files.
+        run: make appstore APP_VERSION=${{ steps.meta.outputs.version }}
+
+      - name: Sanity-check the build
+        # `make appstore` exits 0 even when the webpack build emits nothing, so
+        # guard against shipping a tarball without JS bundles.
+        run: |
+          count=$(tar tzf build/artifacts/appstore/files_archive.tar.gz | grep -c 'files_archive/js/.*\.js$' || true)
+          echo "JS bundles in archive: $count"
+          test "$count" -gt 0 || { echo "::error::No JS bundles in the archive - the webpack build produced nothing"; exit 1; }
+
+      - name: Name the artifact after the version
+        run: cp build/artifacts/appstore/files_archive.tar.gz "files_archive-${{ steps.meta.outputs.version }}.tar.gz"
+
+      - name: Upload as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: files_archive-${{ steps.meta.outputs.version }}
+          path: files_archive-${{ steps.meta.outputs.version }}.tar.gz
+          if-no-files-found: error
+
+      - name: Attach to the GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: files_archive-${{ steps.meta.outputs.version }}.tar.gz
+          fail_on_unmatched_files: true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,19 @@ webpackConfig.output = {
   compareBeforeEmit: true, // true would break the Makefile
 };
 
+// The base @nextcloud/webpack-vue-config sets `devtool: 'source-map'` for
+// production. That makes both the source-map devtool and csso-webpack-plugin
+// (CSS minification) emit a `<name>.css.map` for every extracted stylesheet
+// with different content, which webpack reports as "Conflict: Multiple assets
+// emit different content to the same filename css/...css.map". Since the
+// production mode also sets `optimization.emitOnErrors = false`, those errors
+// suppress *all* emitted assets and `make appstore` ends up packaging an empty
+// js/ directory. The production ("appstore") build is meant to be minified and
+// without debugging info anyway, so just drop the source maps there.
+if (productionMode) {
+  webpackConfig.devtool = false;
+}
+
 const svgoOptions = {
   multipass: true,
   js2svg: {
@@ -74,6 +87,13 @@ webpackConfig.plugins = webpackConfig.plugins.concat([
     exclude: [
       'node_modules',
     ],
+    // Linting must not break the production ("appstore") bundle: in production
+    // ESLint findings are neither emitted as webpack errors (which, together
+    // with optimization.emitOnErrors === false, would suppress every emitted
+    // asset) nor allowed to fail the build. Linting stays active for the
+    // development build.
+    failOnError: !productionMode,
+    emitError: !productionMode,
   }),
   new HtmlWebpackPlugin({
     inject: false,


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds the ready-to-use app archive (`make appstore`) whenever a `v*` tag is pushed and attaches `files_archive-<version>.tar.gz` to the GitHub release, so users can install the app without checking out the sources and building them locally. The workflow can also be triggered manually (`workflow_dispatch`) to test the build without tagging; in that case the tarball is only kept as a workflow artifact.

For the workflow to produce a usable archive, one build fix is needed first: on a clean checkout the production webpack build currently emits **no assets at all**, while `make appstore` still exits 0 and happily packages a tarball without any JavaScript. Two production settings inherited from `@nextcloud/webpack-vue-config` are to blame, both turned fatal by `optimization.emitOnErrors = false`:

- `devtool: 'source-map'` makes the source-map devtool and csso-webpack-plugin each emit a `<name>.css.map` for every extracted stylesheet with different content — webpack reports ~10 `Conflict: Multiple assets emit different content to the same filename css/....css.map` errors and, since emitting on errors is disabled in production mode, suppresses *every* asset;
- the ESLint webpack plugin reports findings as build errors.

The first commit restricts both to the development build: source maps are dropped in production (the appstore build is meant to be minified anyway) and ESLint is made non-fatal there. Linting and source maps in the development build are unchanged.

Notes on the workflow itself:

- `libxml-xpath-perl` is installed on the runner because `dev-scripts/lib/makefile/setup.mk` needs the `xpath` binary to parse the app name and the supported cloud versions out of `appinfo/info.xml`; its fallback path only works inside a server tree (it greps `../../version.php`) and expands a self-referencing `CLOUD_MAX_VERSION`, which is fatal for make.
- `APP_VERSION` is not derived from `info.xml` by the Makefile, so the workflow reads it with PHP and passes it on the make command line, getting it embedded into the generated app-config files.
- A sanity-check step fails the run if the archive contains no JS bundles, guarding against regressions of the "empty tarball" failure mode described above (`make appstore` masks webpack's exit code).
- If the `APP_PRIVATE_KEY` secret is ever configured, the Makefile's existing signing support picks it up automatically; without it the archive is simply unsigned, as with a local `make appstore`.

I verified the result by running the same steps as the workflow (PHP 8.4, Node 24, clean checkout with submodules) in a container: without the first commit webpack fails with the `css.map` conflicts and packages an empty `js/`; with it the build compiles with 0 errors and the tarball contains all four entry points, minified. <!-- se hai anche provato il workflow_dispatch/tag sul fork, aggiungi: "The workflow itself was exercised on my fork via ... and the run succeeded / the tarball was attached to the release." -->