### PR TITLE
Add an "Extract here" entry to the file-actions menu

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -125,6 +125,9 @@ return [
       'name' => 'archive#extract',
       'url' => '/archive/extract/{archivePath}/{targetPath}',
       'verb' => 'POST',
+      'defaults' => [
+        'targetPath' => null,
+      ],
     ],
     // diagnostics output
     [

--- a/src/files-hooks.ts
+++ b/src/files-hooks.ts
@@ -32,6 +32,7 @@ import { translate as t } from '@nextcloud/l10n';
 import logoSvg from '../img/app.svg?raw';
 import { appName } from './config.ts';
 import logger from './console.ts';
+import extract from './services/extract.ts';
 import mount from './services/mount.ts';
 import { fileInfoToNode } from './toolkit/util/file-node-helper.ts';
 import getInitialState from './toolkit/util/initial-state.ts';
@@ -87,4 +88,29 @@ registerFileAction({
   exec: (context) => mount(context.nodes[0], context.view),
   default: initialState?.mountByLeftClick ? DefaultType.DEFAULT : undefined,
   order: -1000,
+});
+
+registerFileAction({
+  id: appName + '-extract',
+  displayName(_context) {
+    return t(appName, 'Extract here');
+  },
+  title(_context: ActionContext) {
+    return t(appName, 'Extract the archive to a new folder in the current directory');
+  },
+  iconSvgInline(_context: ActionContext) {
+    return logoSvg;
+  },
+  enabled(context: ActionContext) {
+    if (context.nodes.length !== 1) {
+      return false;
+    }
+    const node = context.nodes[0];
+    if (!(node.permissions & Permission.READ)) {
+      return false;
+    }
+    return node.mime !== undefined && archiveMimeTypes.findIndex((mime) => mime === node.mime) >= 0;
+  },
+  exec: (context) => extract(context.nodes[0]),
+  order: -999,
 });

--- a/src/services/extract.ts
+++ b/src/services/extract.ts
@@ -1,0 +1,119 @@
+/**
+ * @author Claus-Justus Heine <himself@claus-justus-heine.de>
+ * @author Fabio Fantoni <fabio.fantoni@m2r.biz>
+ * @copyright 2025, 2026 Claus-Justus Heine
+ * @copyright 2026 Fabio Fantoni
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { INode } from '@nextcloud/files';
+import type { FileInfoDTO } from '../toolkit/util/file-node-helper.ts';
+import type { InitialState } from '../types/initial-state.d.ts';
+
+import axios from '@nextcloud/axios';
+import { showError, showSuccess, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs';
+import { emit } from '@nextcloud/event-bus';
+import { NodeStatus } from '@nextcloud/files';
+import { translate as t } from '@nextcloud/l10n';
+import { appName } from '../config.ts';
+import logger from '../console.ts';
+import { isAxiosErrorResponse } from '../toolkit/types/axios-type-guards.ts';
+import { fileInfoToNode } from '../toolkit/util/file-node-helper.ts';
+import generateAppUrl from '../toolkit/util/generate-url.ts';
+import getInitialState from '../toolkit/util/initial-state.ts';
+
+const initialState = getInitialState<InitialState>();
+
+interface ExtractResponse {
+  archivePath: string;
+  targetFileId: number;
+  targetPath: string;
+  targetFolder: FileInfoDTO;
+  messages: string[];
+}
+
+/**
+ * Extract the given archive file to a fresh folder in its parent
+ * directory. The folder name is determined by the server from the
+ * configured extraction folder template.
+ *
+ * @param node The file-system node referring to the archive file.
+ *
+ * @return null, status feedback is provided by toasts.
+ */
+const extract = async (node: INode) => {
+  const savedNodeStatus = node.status;
+
+  const encodedPath = encodeURIComponent(node.path);
+
+  try {
+    if (initialState?.extractBackgroundJob) {
+      const extractUrl = generateAppUrl('archive/schedule/extract/{encodedPath}', { encodedPath }, undefined);
+      const response = await axios.post<{ targetPath: string; jobType: string; messages: string[] }>(extractUrl);
+      const targetPath = response.data.targetPath;
+      showSuccess(t(appName, 'The archive "{archivePath}" will be extracted asynchronously to "{targetPath}", you will be notified on completion.', {
+        archivePath: node.path,
+        targetPath,
+      }));
+    } else {
+      node.status = NodeStatus.LOADING;
+      emit('files:node:updated', node);
+      const extractUrl = generateAppUrl('archive/extract/{encodedPath}', { encodedPath }, undefined);
+      const response = await axios.post<ExtractResponse>(extractUrl, {
+        stripCommonPathPrefix: !!initialState?.extractStripCommonPathPrefixDefault,
+      });
+      const data = response.data;
+      logger.info('DATA', data);
+      showSuccess(t(appName, 'The archive "{archivePath}" has been extracted to "{targetPath}".', {
+        archivePath: node.path,
+        targetPath: data.targetPath,
+      }));
+      const targetNode = fileInfoToNode(data.targetFolder);
+      logger.info('TARGET NODE', targetNode);
+
+      // Update files list
+      emit('files:node:created', targetNode);
+
+      node.status = undefined;
+      emit('files:node:updated', node);
+    }
+  } catch (e) {
+    logger.error('ERROR', e);
+    if (isAxiosErrorResponse(e)) {
+      const messages: string[] = [];
+      if (e.response.data) {
+        const responseData = e.response.data as { messages?: string[] };
+        if (responseData.messages) {
+          messages.splice(messages.length, 0, ...responseData.messages);
+        }
+      }
+      if (!messages.length) {
+        messages.push(t(appName, 'Extraction request failed with error {status}, "{statusText}".', {
+          status: e.response.status,
+          statusText: e.response.statusText,
+        }));
+      }
+      for (const message of messages) {
+        showError(message, { timeout: TOAST_PERMANENT_TIMEOUT });
+      }
+    }
+  }
+  node.status = savedNodeStatus;
+  emit('files:node:updated', node);
+  return null;
+};
+
+export default extract;


### PR DESCRIPTION
Extracting an archive previously required opening the details sidebar and using the extraction controls of the Archive tab. Add a one-click "Extract here" file action, similar to the (abandoned) "Extract" app, which extracts the archive to a new folder in the current directory.

The target folder name is determined server side from the configured extraction folder template; the personal "strip common path prefix" and "background job" defaults are honoured. Success and errors are reported via toasts and the files list picks up the new folder without a reload.

The archive#extract route gains a default null targetPath (like the mount route already had) so that the action can rely on the server-side default target name.