### PR TITLE
Add basic CI checks for pull requests

### DIFF
--- a/.github/workflows/build-appstore.yml
+++ b/.github/workflows/build-appstore.yml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Reusable workflow building the ready-to-use app archive (the same
+# artifact as `make appstore`) and uploading it as a workflow artifact.
+# It serves both as the build stage of the release workflow and as a
+# check on pull requests, so the two can never drift apart.
+name: Build app archive
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: The app version read from appinfo/info.xml
+        value: ${{ jobs.build.outputs.version }}
+      artifact:
+        description: Name of the uploaded tarball artifact
+        value: files_archive-${{ jobs.build.outputs.version }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # dev-scripts/MakeHelp is a git submodule required by the Makefile.
+          submodules: recursive
+
+      - name: Install xpath
+        # dev-scripts/lib/makefile/setup.mk needs the xpath binary to parse
+        # the app name and the supported cloud versions out of
+        # appinfo/info.xml; its fallback path only works inside a server tree.
+        run: sudo apt-get install -y libxml-xpath-perl
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Read app version
+        id: meta
+        run: |
+          version=$(php -r 'echo (string)simplexml_load_file("appinfo/info.xml")->version;')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build app archive
+        # APP_VERSION is not derived from info.xml by the Makefile, so pass it
+        # explicitly to get it embedded into the generated app-config files.
+        run: make appstore APP_VERSION=${{ steps.meta.outputs.version }}
+
+      - name: Sanity-check the build
+        # `make appstore` exits 0 even when the webpack build emits nothing, so
+        # guard against shipping a tarball without JS bundles.
+        run: |
+          count=$(tar tzf build/artifacts/appstore/files_archive.tar.gz | grep -c 'files_archive/js/.*\.js$' || true)
+          echo "JS bundles in archive: $count"
+          test "$count" -gt 0 || { echo "::error::No JS bundles in the archive - the webpack build produced nothing"; exit 1; }
+
+      - name: Name the artifact after the version
+        run: cp build/artifacts/appstore/files_archive.tar.gz "files_archive-${{ steps.meta.outputs.version }}.tar.gz"
+
+      - name: Upload as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: files_archive-${{ steps.meta.outputs.version }}
+          path: files_archive-${{ steps.meta.outputs.version }}.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Basic checks on pull requests and pushes to main: eslint over the
+# frontend sources, php -l over the PHP sources for every supported PHP
+# version, and a full production build of the app archive via the
+# reusable build-appstore.yml workflow (the same build the release
+# workflow ships, so regressions in it surface before tagging).
+name: CI
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        # package-lock.json is not tracked, so `npm ci` is not available.
+        run: npm install
+
+      - name: Run eslint
+        run: npm run lint
+
+  php-lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['8.4', '8.5']
+    name: php-lint (${{ matrix.php-versions }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up PHP ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+
+      - name: Lint PHP files
+        run: find lib appinfo templates php-toolkit -name '*.php' -print0 | xargs -0 -n1 -P4 php -l
+
+  build:
+    uses: ./.github/workflows/build-appstore.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build the ready-to-use app archive (the same artifact as `make appstore`)
+# and attach it to the GitHub release whenever a `v*` tag is pushed. The
+# job can also be triggered manually (workflow_dispatch) to test the build
+# without creating a tag; in that case the tarball is only kept as a
+# workflow artifact and not attached to any release.
+name: Build release tarball
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # dev-scripts/MakeHelp is a git submodule required by the Makefile.
+          submodules: recursive
+
+      - name: Install xpath
+        # dev-scripts/lib/makefile/setup.mk needs the xpath binary to parse
+        # the app name and the supported cloud versions out of
+        # appinfo/info.xml; its fallback path only works inside a server tree.
+        run: sudo apt-get install -y libxml-xpath-perl
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Read app version
+        id: meta
+        run: |
+          version=$(php -r 'echo (string)simplexml_load_file("appinfo/info.xml")->version;')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build app archive
+        # APP_VERSION is not derived from info.xml by the Makefile, so pass it
+        # explicitly to get it embedded into the generated app-config files.
+        run: make appstore APP_VERSION=${{ steps.meta.outputs.version }}
+
+      - name: Sanity-check the build
+        # `make appstore` exits 0 even when the webpack build emits nothing, so
+        # guard against shipping a tarball without JS bundles.
+        run: |
+          count=$(tar tzf build/artifacts/appstore/files_archive.tar.gz | grep -c 'files_archive/js/.*\.js$' || true)
+          echo "JS bundles in archive: $count"
+          test "$count" -gt 0 || { echo "::error::No JS bundles in the archive - the webpack build produced nothing"; exit 1; }
+
+      - name: Name the artifact after the version
+        run: cp build/artifacts/appstore/files_archive.tar.gz "files_archive-${{ steps.meta.outputs.version }}.tar.gz"
+
+      - name: Upload as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: files_archive-${{ steps.meta.outputs.version }}
+          path: files_archive-${{ steps.meta.outputs.version }}.tar.gz
+          if-no-files-found: error
+
+      - name: Attach to the GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: files_archive-${{ steps.meta.outputs.version }}.tar.gz
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
-# Build the ready-to-use app archive (the same artifact as `make appstore`)
-# and attach it to the GitHub release whenever a `v*` tag is pushed. The
-# job can also be triggered manually (workflow_dispatch) to test the build
-# without creating a tag; in that case the tarball is only kept as a
-# workflow artifact and not attached to any release.
+# Attach the ready-to-use app archive to the GitHub release whenever a
+# `v*` tag is pushed. The build itself lives in the reusable
+# build-appstore.yml workflow, shared with the CI checks on pull
+# requests. The job can also be triggered manually (workflow_dispatch)
+# to test the build without creating a tag; in that case the tarball is
+# only kept as a workflow artifact and not attached to any release.
 name: Build release tarball
 
 on:
@@ -18,63 +19,22 @@ permissions:
 
 jobs:
   build:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-appstore.yml
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Download the tarball artifact
+        uses: actions/download-artifact@v4
         with:
-          # dev-scripts/MakeHelp is a git submodule required by the Makefile.
-          submodules: recursive
-
-      - name: Install xpath
-        # dev-scripts/lib/makefile/setup.mk needs the xpath binary to parse
-        # the app name and the supported cloud versions out of
-        # appinfo/info.xml; its fallback path only works inside a server tree.
-        run: sudo apt-get install -y libxml-xpath-perl
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.4'
-          tools: composer
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Read app version
-        id: meta
-        run: |
-          version=$(php -r 'echo (string)simplexml_load_file("appinfo/info.xml")->version;')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Build app archive
-        # APP_VERSION is not derived from info.xml by the Makefile, so pass it
-        # explicitly to get it embedded into the generated app-config files.
-        run: make appstore APP_VERSION=${{ steps.meta.outputs.version }}
-
-      - name: Sanity-check the build
-        # `make appstore` exits 0 even when the webpack build emits nothing, so
-        # guard against shipping a tarball without JS bundles.
-        run: |
-          count=$(tar tzf build/artifacts/appstore/files_archive.tar.gz | grep -c 'files_archive/js/.*\.js$' || true)
-          echo "JS bundles in archive: $count"
-          test "$count" -gt 0 || { echo "::error::No JS bundles in the archive - the webpack build produced nothing"; exit 1; }
-
-      - name: Name the artifact after the version
-        run: cp build/artifacts/appstore/files_archive.tar.gz "files_archive-${{ steps.meta.outputs.version }}.tar.gz"
-
-      - name: Upload as workflow artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: files_archive-${{ steps.meta.outputs.version }}
-          path: files_archive-${{ steps.meta.outputs.version }}.tar.gz
-          if-no-files-found: error
+          name: ${{ needs.build.outputs.artifact }}
 
       - name: Attach to the GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: files_archive-${{ steps.meta.outputs.version }}.tar.gz
+          files: files_archive-${{ needs.build.outputs.version }}.tar.gz
           fail_on_unmatched_files: true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,19 @@ webpackConfig.output = {
   compareBeforeEmit: true, // true would break the Makefile
 };
 
+// The base @nextcloud/webpack-vue-config sets `devtool: 'source-map'` for
+// production. That makes both the source-map devtool and csso-webpack-plugin
+// (CSS minification) emit a `<name>.css.map` for every extracted stylesheet
+// with different content, which webpack reports as "Conflict: Multiple assets
+// emit different content to the same filename css/...css.map". Since the
+// production mode also sets `optimization.emitOnErrors = false`, those errors
+// suppress *all* emitted assets and `make appstore` ends up packaging an empty
+// js/ directory. The production ("appstore") build is meant to be minified and
+// without debugging info anyway, so just drop the source maps there.
+if (productionMode) {
+  webpackConfig.devtool = false;
+}
+
 const svgoOptions = {
   multipass: true,
   js2svg: {
@@ -74,6 +87,13 @@ webpackConfig.plugins = webpackConfig.plugins.concat([
     exclude: [
       'node_modules',
     ],
+    // Linting must not break the production ("appstore") bundle: in production
+    // ESLint findings are neither emitted as webpack errors (which, together
+    // with optimization.emitOnErrors === false, would suppress every emitted
+    // asset) nor allowed to fail the build. Linting stays active for the
+    // development build.
+    failOnError: !productionMode,
+    emitError: !productionMode,
   }),
   new HtmlWebpackPlugin({
     inject: false,


### PR DESCRIPTION
This PR adds a minimal, non-invasive set of CI checks so that pull requests get some automatic feedback:

- **eslint** over the frontend sources (`npm run lint` — currently passes clean on `main`);
- **php -l** over `lib/`, `appinfo/`, `templates/` and `php-toolkit/` for the supported PHP versions (8.4, 8.5);
- a **full production build** of the app archive, including the no-JS-bundles sanity check, so a broken appstore build surfaces in the PR instead of at tag time.

To avoid the PR build and the release build ever drifting apart, the first commit moves the build steps of the release workflow (#65) into a reusable `build-appstore.yml` workflow (`workflow_call`); the release workflow now just calls it and attaches the resulting artifact to the release on tags. No functional change for tag pushes or manual dispatches. *(Note: this PR is stacked on top of #65 and includes its commits.)*

Deliberately left out for now, your call if/how to go further:

- **phpcs**: `make phpcs` currently reports ~24 errors (partly in generated `lib/Toolkit/`, which probably should not be linted at all), so a blocking gate would fail immediately; it could be added after a cleanup pass, or as a non-blocking informational job.
- **stylelint**: the current configuration is not compatible with the installed stylelint version (thousands of "Unknown rule" errors), so it needs fixing before it can run in CI.
- **phpunit**: `tests/Unit` and `tests/Integration` are empty at the moment.
- **functional regression tests**: end-to-end tests of the essential features (mount, extraction, sidebar tab) against a real Nextcloud instance in CI would be the most valuable long-term addition — happy to explore that in a follow-up if you're interested.

FYI, `php -l` on PHP 8.4 also prints a (non-fatal) deprecation for `ArchiveStoragePreNC31::writeStream()`: the `$size` parameter is implicitly nullable and should be declared `?int`.