### PR TITLE
Add admin and personal option to disable mounting of archive files

### DIFF
--- a/lib/Controller/MountController.php
+++ b/lib/Controller/MountController.php
@@ -78,6 +78,12 @@ class MountController extends Controller
   /** @var bool */
   private bool $stripCommonPathPrefixDefault = false;
 
+  /** @var bool */
+  private bool $mountDisabledAdmin = false;
+
+  /** @var bool */
+  private bool $mountDisabled = false;
+
   /** @var null|int */
   private ?int $archiveSizeLimit = null;
 
@@ -118,6 +124,12 @@ class MountController extends Controller
 
       $this->stripCommonPathPrefixDefault = (bool)$cloudConfig->getUserValue(
         $this->userId, $this->appName, SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT, false);
+
+      $this->mountDisabledAdmin = (bool)$cloudConfig->getAppValue(
+        $this->appName, SettingsController::MOUNT_DISABLED, SettingsController::MOUNT_DISABLED_DEFAULT);
+
+      $this->mountDisabled = $this->mountDisabledAdmin || (bool)$cloudConfig->getUserValue(
+        $this->userId, $this->appName, SettingsController::MOUNT_DISABLED, SettingsController::MOUNT_DISABLED_DEFAULT);
     }
   }
   // phpcs:enable
@@ -140,6 +152,13 @@ class MountController extends Controller
     ?string $passPhrase = null,
     ?bool $stripCommonPathPrefix = null,
   ) {
+    if ($this->mountDisabledAdmin) {
+      return self::grumble($this->l->t('Mounting of archive files has been disabled by the administrator.'));
+    }
+    if ($this->mountDisabled) {
+      return self::grumble($this->l->t('Mounting of archive files has been disabled in your personal settings.'));
+    }
+
     $archivePath = urldecode($archivePath);
     if ($mountPointPath) {
       $mountPointPath = urldecode($mountPointPath);

--- a/lib/Controller/MountController.php
+++ b/lib/Controller/MountController.php
@@ -78,6 +78,9 @@ class MountController extends Controller
   /** @var bool */
   private bool $stripCommonPathPrefixDefault = false;
 
+  /** @var bool */
+  private bool $mountDisabled = false;
+
   /** @var null|int */
   private ?int $archiveSizeLimit = null;
 
@@ -118,6 +121,12 @@ class MountController extends Controller
 
       $this->stripCommonPathPrefixDefault = (bool)$cloudConfig->getUserValue(
         $this->userId, $this->appName, SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT, false);
+
+      $mountDisabledDefault = (bool)$cloudConfig->getAppValue(
+        $this->appName, SettingsController::MOUNT_DISABLED, SettingsController::MOUNT_DISABLED_DEFAULT);
+
+      $this->mountDisabled = (bool)$cloudConfig->getUserValue(
+        $this->userId, $this->appName, SettingsController::MOUNT_DISABLED, $mountDisabledDefault);
     }
   }
   // phpcs:enable
@@ -147,6 +156,11 @@ class MountController extends Controller
     ?string $passPhrase = null,
     ?bool $stripCommonPathPrefix = null,
   ) {
+    if ($this->mountDisabled) {
+      return self::grumble(
+        $this->l->t('Mounting of archive files is disabled. You can enable it in your personal settings.'));
+    }
+
     $archivePath = urldecode($archivePath);
     if ($mountPointPath) {
       $mountPointPath = urldecode($mountPointPath);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -60,6 +60,7 @@ class SettingsController extends Controller
    */
   const ADMIN_SETTINGS = [
     self::ARCHIVE_SIZE_LIMIT => [ 'rw' => true, 'default' => self::DEFAULT_ADMIN_ARCHIVE_SIZE_LIMIT ],
+    self::MOUNT_DISABLED => [ 'rw' => true, 'default' => self::MOUNT_DISABLED_DEFAULT ],
   ];
 
   public const MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT = 'mountStripCommonPathPrefixDefault';
@@ -87,6 +88,10 @@ class SettingsController extends Controller
   public const MOUNT_BY_LEFT_CLICK = 'mountByLeftClick';
   public const MOUNT_BY_LEFT_CLICK_DEFAULT = false;
 
+  public const MOUNT_DISABLED = 'mountDisabled';
+  public const MOUNT_DISABLED_DEFAULT = false;
+  public const MOUNT_DISABLED_ADMIN = self::MOUNT_DISABLED . self::ADMIN_SETTING;
+
   /**
    * @var array<string, array>
    *
@@ -104,6 +109,8 @@ class SettingsController extends Controller
     self::MOUNT_BACKGROUND_JOB => [ 'rw' => true, 'default' => self::MOUNT_BACKGROUND_JOB_DEFAULT ],
     self::EXTRACT_BACKGROUND_JOB => [ 'rw' => true, 'default' => self::EXTRACT_BACKGROUND_JOB_DEFAULT ],
     self::MOUNT_BY_LEFT_CLICK => [ 'rw' => true, 'default' => self::MOUNT_BY_LEFT_CLICK_DEFAULT ],
+    self::MOUNT_DISABLED => [ 'rw' => true, 'default' => self::MOUNT_DISABLED_DEFAULT ],
+    self::MOUNT_DISABLED_ADMIN => [ 'rw' => false, 'default' => self::MOUNT_DISABLED_DEFAULT ],
   ];
 
   // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
@@ -152,6 +159,20 @@ class SettingsController extends Controller
           $newValue = $this->parseMemorySize($value);
         } catch (InvalidArgumentException $t) {
           return self::grumble($t->getMessage());
+        }
+        break;
+      case self::MOUNT_DISABLED:
+        $newValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]);
+        if ($newValue === null) {
+          return self::grumble(
+            $this->l->t('Value "%1$s" for setting "%2$s" is not convertible to boolean.', [
+              $value, $setting,
+            ]));
+        }
+        if ($newValue === (self::ADMIN_SETTINGS[$setting]['default'] ?? false)) {
+          $newValue = null;
+        } else {
+          $newValue = (int)$newValue;
         }
         break;
       default:
@@ -214,6 +235,10 @@ class SettingsController extends Controller
             $humanValue = '';
           }
           break;
+        case self::MOUNT_DISABLED:
+          $value = (bool)$value;
+          $humanValue = $value;
+          break;
         default:
           return self::grumble($this->l->t('Unknown admin setting: "%1$s"', $oneSetting));
       }
@@ -267,6 +292,7 @@ class SettingsController extends Controller
       case self::EXTRACT_TARGET_AUTO_RENAME:
       case self::MOUNT_BACKGROUND_JOB:
       case self::MOUNT_BY_LEFT_CLICK:
+      case self::MOUNT_DISABLED:
       case self::MOUNT_POINT_AUTO_RENAME:
       case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
         $oldValue = filter_var($oldValue, FILTER_VALIDATE_BOOLEAN);
@@ -383,6 +409,8 @@ class SettingsController extends Controller
         case self::EXTRACT_TARGET_TEMPLATE:
         case self::MOUNT_BACKGROUND_JOB:
         case self::MOUNT_BY_LEFT_CLICK:
+        case self::MOUNT_DISABLED:
+        case self::MOUNT_DISABLED_ADMIN:
         case self::MOUNT_POINT_AUTO_RENAME:
         case self::MOUNT_POINT_TEMPLATE:
         case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -60,6 +60,7 @@ class SettingsController extends Controller
    */
   const ADMIN_SETTINGS = [
     self::ARCHIVE_SIZE_LIMIT => [ 'rw' => true, 'default' => self::DEFAULT_ADMIN_ARCHIVE_SIZE_LIMIT ],
+    self::MOUNT_DISABLED => [ 'rw' => true, 'default' => self::MOUNT_DISABLED_DEFAULT ],
   ];
 
   public const MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT = 'mountStripCommonPathPrefixDefault';
@@ -87,6 +88,10 @@ class SettingsController extends Controller
   public const MOUNT_BY_LEFT_CLICK = 'mountByLeftClick';
   public const MOUNT_BY_LEFT_CLICK_DEFAULT = false;
 
+  public const MOUNT_DISABLED = 'mountDisabled';
+  public const MOUNT_DISABLED_DEFAULT = false;
+  public const MOUNT_DISABLED_ADMIN = self::MOUNT_DISABLED . self::ADMIN_SETTING;
+
   /**
    * @var array<string, array>
    *
@@ -104,6 +109,8 @@ class SettingsController extends Controller
     self::MOUNT_BACKGROUND_JOB => [ 'rw' => true, 'default' => self::MOUNT_BACKGROUND_JOB_DEFAULT ],
     self::EXTRACT_BACKGROUND_JOB => [ 'rw' => true, 'default' => self::EXTRACT_BACKGROUND_JOB_DEFAULT ],
     self::MOUNT_BY_LEFT_CLICK => [ 'rw' => true, 'default' => self::MOUNT_BY_LEFT_CLICK_DEFAULT ],
+    self::MOUNT_DISABLED => [ 'rw' => true, 'default' => self::MOUNT_DISABLED_DEFAULT ],
+    self::MOUNT_DISABLED_ADMIN => [ 'rw' => false, 'default' => self::MOUNT_DISABLED_DEFAULT ],
   ];
 
   // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
@@ -153,6 +160,20 @@ class SettingsController extends Controller
           $newValue = $this->parseMemorySize($value);
         } catch (InvalidArgumentException $t) {
           return self::grumble($t->getMessage());
+        }
+        break;
+      case self::MOUNT_DISABLED:
+        $newValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]);
+        if ($newValue === null) {
+          return self::grumble(
+            $this->l->t('Value "%1$s" for setting "%2$s" is not convertible to boolean.', [
+              $value, $setting,
+            ]));
+        }
+        if ($newValue === (self::ADMIN_SETTINGS[$setting]['default'] ?? false)) {
+          $newValue = null;
+        } else {
+          $newValue = (int)$newValue;
         }
         break;
       default:
@@ -224,6 +245,10 @@ class SettingsController extends Controller
             $humanValue = '';
           }
           break;
+        case self::MOUNT_DISABLED:
+          $value = (bool)$value;
+          $humanValue = $value;
+          break;
         default:
           return self::grumble($this->l->t('Unknown admin setting: "%1$s"', $oneSetting));
       }
@@ -291,6 +316,21 @@ class SettingsController extends Controller
         if ($newValue === (self::PERSONAL_SETTINGS[$setting]['default'] ?? false)) {
           $newValue = null;
         }
+        break;
+      case self::MOUNT_DISABLED:
+        $oldValue = filter_var(
+          $this->config->getUserValue($this->userId, $this->appName, $setting, $this->mountDisabledDefault()),
+          FILTER_VALIDATE_BOOLEAN);
+        $newValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]);
+        if ($newValue === null) {
+          return self::grumble(
+            $this->l->t('Value "%1$s" for setting "%2$s" is not convertible to boolean.', [
+              $value, $setting,
+            ]));
+        }
+        // The personal value overrides the administrative default in both
+        // directions, so it has to be recorded even when it happens to match
+        // the current default.
         break;
       case self::MOUNT_POINT_TEMPLATE:
       case self::EXTRACT_TARGET_TEMPLATE:
@@ -380,6 +420,12 @@ class SettingsController extends Controller
           $adminKey,
           self::ADMIN_SETTINGS[$adminKey]['default'] ?? null,
         );
+      } elseif ($oneSetting === self::MOUNT_DISABLED) {
+        $value = $this->config->getUserValue(
+          $this->userId,
+          $this->appName,
+          $oneSetting,
+          $this->mountDisabledDefault());
       } else {
         $value = $this->config->getUserValue(
           $this->userId,
@@ -407,6 +453,8 @@ class SettingsController extends Controller
         case self::EXTRACT_TARGET_AUTO_RENAME:
         case self::MOUNT_BACKGROUND_JOB:
         case self::MOUNT_BY_LEFT_CLICK:
+        case self::MOUNT_DISABLED:
+        case self::MOUNT_DISABLED_ADMIN:
         case self::MOUNT_POINT_AUTO_RENAME:
         case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
           $value = !!$value;
@@ -426,6 +474,18 @@ class SettingsController extends Controller
         'humanValue' => $results['human' . ucfirst($setting)],
       ]);
     }
+  }
+
+  /**
+   * The administrative setting for the mount-disabled switch only defines the
+   * default for the users, who may override it in both directions.
+   *
+   * @return bool
+   */
+  private function mountDisabledDefault(): bool
+  {
+    return (bool)$this->config->getAppValue(
+      $this->appName, self::MOUNT_DISABLED, self::MOUNT_DISABLED_DEFAULT);
   }
 
   /**

--- a/lib/Listener/FilesActionListener.php
+++ b/lib/Listener/FilesActionListener.php
@@ -148,6 +148,10 @@ class FilesActionListener implements IEventListener
           $userId, $appName, SettingsController::EXTRACT_BACKGROUND_JOB, SettingsController::EXTRACT_BACKGROUND_JOB_DEFAULT),
         SettingsController::MOUNT_BY_LEFT_CLICK => $cloudConfig->getUserValue(
           $userId, $appName, SettingsController::MOUNT_BY_LEFT_CLICK, SettingsController::MOUNT_BY_LEFT_CLICK_DEFAULT),
+        SettingsController::MOUNT_DISABLED => (bool)$cloudConfig->getAppValue(
+          $appName, SettingsController::MOUNT_DISABLED, SettingsController::MOUNT_DISABLED_DEFAULT)
+          || (bool)$cloudConfig->getUserValue(
+            $userId, $appName, SettingsController::MOUNT_DISABLED, SettingsController::MOUNT_DISABLED_DEFAULT),
         SettingsController::MOUNT_POINT_TEMPLATE => SettingsController::FOLDER_TEMPLATE_DEFAULT,
         SettingsController::EXTRACT_TARGET_TEMPLATE => SettingsController::FOLDER_TEMPLATE_DEFAULT,
       ]);

--- a/lib/Listener/FilesActionListener.php
+++ b/lib/Listener/FilesActionListener.php
@@ -148,6 +148,9 @@ class FilesActionListener implements IEventListener
           $userId, $appName, SettingsController::EXTRACT_BACKGROUND_JOB, SettingsController::EXTRACT_BACKGROUND_JOB_DEFAULT),
         SettingsController::MOUNT_BY_LEFT_CLICK => $cloudConfig->getUserValue(
           $userId, $appName, SettingsController::MOUNT_BY_LEFT_CLICK, SettingsController::MOUNT_BY_LEFT_CLICK_DEFAULT),
+        SettingsController::MOUNT_DISABLED => (bool)$cloudConfig->getUserValue(
+          $userId, $appName, SettingsController::MOUNT_DISABLED, (bool)$cloudConfig->getAppValue(
+            $appName, SettingsController::MOUNT_DISABLED, SettingsController::MOUNT_DISABLED_DEFAULT)),
         SettingsController::MOUNT_POINT_TEMPLATE => SettingsController::FOLDER_TEMPLATE_DEFAULT,
         SettingsController::EXTRACT_TARGET_TEMPLATE => SettingsController::FOLDER_TEMPLATE_DEFAULT,
       ]);

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -31,6 +31,20 @@
                  @submit="saveTextInput('archiveSizeLimit', settings.humanArchiveSizeLimit)"
       />
     </NcSettingsSection>
+    <NcSettingsSection :name="t(appName, 'Archive Mounting')">
+      <div class="settings-option">
+        <input id="files-archive-admin-mount-disabled"
+               v-model="settings.mountDisabled"
+               type="checkbox"
+               class="checkbox"
+               :disabled="loading"
+               @change="saveSetting('mountDisabled')"
+        >
+        <label for="files-archive-admin-mount-disabled">
+          {{ t(appName, 'disable mounting of archive files for all users') }}
+        </label>
+      </div>
+    </NcSettingsSection>
     <NcSettingsSection :name="t(appName, 'Diagnostics')" class="diagnostics">
       <h3>{{ t(appName, "Archive Formats") }}</h3>
       <!-- eslint-disable-next-line vue/no-v-html -->
@@ -62,6 +76,7 @@ import { generateUrl as generateAppUrl } from './toolkit/util/generate-url.ts'
 import {
   fetchSettings,
   saveConfirmedSetting,
+  saveSimpleSetting,
 } from './toolkit/util/settings-sync.ts'
 
 const cloudVersionClasses = computed<string[]>(() => cloudVersionClassesImport)
@@ -70,6 +85,7 @@ const loading = ref(true)
 const settings = reactive({
   archiveSizeLimit: 0x100000000,
   humanArchiveSizeLimit: '',
+  mountDisabled: false,
 })
 
 const diagnostics = reactive({
@@ -91,6 +107,15 @@ const saveTextInput = async (settingsKey: string, value?: string, force?: boolea
     value = settings[settingsKey] || ''
   }
   return saveConfirmedSetting({ value, section: 'admin', settingsKey, force, settings })
+}
+
+const saveSetting = async (settingsKey: string) => {
+  if (loading.value) {
+    // avoid ping-pong by reactivity
+    logger.info('SKIPPING SETTINGS-SAVE DURING LOAD', settingsKey)
+    return
+  }
+  return saveSimpleSetting({ settingsKey, section: 'admin', settings })
 }
 
 /** TBD */

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -31,6 +31,23 @@
                  @submit="saveTextInput('archiveSizeLimit', settings.humanArchiveSizeLimit)"
       />
     </NcSettingsSection>
+    <NcSettingsSection :name="t(appName, 'Archive Mounting')">
+      <div class="settings-option">
+        <input id="files-archive-admin-mount-disabled"
+               v-model="settings.mountDisabled"
+               type="checkbox"
+               class="checkbox"
+               :disabled="loading"
+               @change="saveSetting('mountDisabled')"
+        >
+        <label for="files-archive-admin-mount-disabled">
+          {{ t(appName, 'disable mounting of archive files by default') }}
+        </label>
+      </div>
+      <span class="hint">
+        {{ t(appName, 'This only defines the default for all users, everybody may override it in the personal settings.') }}
+      </span>
+    </NcSettingsSection>
     <NcSettingsSection :name="t(appName, 'Diagnostics')" class="diagnostics">
       <h3>{{ t(appName, "Archive Formats") }}</h3>
       <!-- eslint-disable-next-line vue/no-v-html -->
@@ -62,6 +79,7 @@ import { generateUrl as generateAppUrl } from './toolkit/util/generate-url.ts'
 import {
   fetchSettings,
   saveConfirmedSetting,
+  saveSimpleSetting,
 } from './toolkit/util/settings-sync.ts'
 
 const cloudVersionClasses = computed<string[]>(() => cloudVersionClassesImport)
@@ -70,6 +88,7 @@ const loading = ref(true)
 const settings = reactive({
   archiveSizeLimit: 0x100000000,
   humanArchiveSizeLimit: '',
+  mountDisabled: false,
 })
 
 const diagnostics = reactive({
@@ -91,6 +110,15 @@ const saveTextInput = async (settingsKey: string, value?: string, force?: boolea
     value = settings[settingsKey] || ''
   }
   return saveConfirmedSetting({ value, section: 'admin', settingsKey, force, settings })
+}
+
+const saveSetting = async (settingsKey: string) => {
+  if (loading.value) {
+    // avoid ping-pong by reactivity
+    logger.info('SKIPPING SETTINGS-SAVE DURING LOAD', settingsKey)
+    return
+  }
+  return saveSimpleSetting({ settingsKey, section: 'admin', settings })
 }
 
 /** TBD */
@@ -159,6 +187,10 @@ async function getDriversStatus() {
     &.flex-center {
       align-items:center;
     }
+  }
+  .hint {
+    color: var(--color-text-lighter);
+    font-size: 80%;
   }
   .diagnostics_output {
     min-height: 2ex;

--- a/src/PersonalSettings.vue
+++ b/src/PersonalSettings.vue
@@ -39,6 +39,21 @@
       </span>
     </NcSettingsSection>
     <NcSettingsSection :name="t(appName, 'Mount Options')">
+      <div class="settings-option">
+        <input :id="id + '-mount-disabled'"
+               v-model="settings.mountDisabled"
+               type="checkbox"
+               class="checkbox"
+               :disabled="!!settings.mountDisabledAdmin"
+               @change="saveSetting('mountDisabled')"
+        >
+        <label :for="id + '-mount-disabled'">
+          {{ t(appName, 'disable mounting of archive files') }}
+        </label>
+      </div>
+      <span v-if="settings.mountDisabledAdmin" class="hint">
+        {{ t(appName, 'Mounting of archive files has been disabled by the administrator.') }}
+      </span>
       <TextField v-model:value="settings.mountPointTemplate"
                  :label="t(appName, 'Template for the default name of the mount point')"
                  :hint="t(appName, '{archiveFileName} will be replaced by the filename of the archive file without extensions.')"
@@ -171,6 +186,8 @@ const settings = reactive({
   humanArchiveSizeLimitAdmin: '',
   mountBackgroundJob: false,
   mountByLeftClick: false,
+  mountDisabled: false,
+  mountDisabledAdmin: false,
   mountPointAutoRename: false,
   mountPointTemplate: '{archiveFileName}',
   mountStripCommonPathPrefixDefault: false,

--- a/src/PersonalSettings.vue
+++ b/src/PersonalSettings.vue
@@ -39,6 +39,20 @@
       </span>
     </NcSettingsSection>
     <NcSettingsSection :name="t(appName, 'Mount Options')">
+      <div class="settings-option">
+        <input :id="id + '-mount-disabled'"
+               v-model="settings.mountDisabled"
+               type="checkbox"
+               class="checkbox"
+               @change="saveSetting('mountDisabled')"
+        >
+        <label :for="id + '-mount-disabled'">
+          {{ t(appName, 'disable mounting of archive files') }}
+        </label>
+      </div>
+      <span v-if="settings.mountDisabledAdmin" class="hint">
+        {{ t(appName, 'The administrator has disabled the mounting of archive files by default, but you may enable it here.') }}
+      </span>
       <TextField v-model="settings.mountPointTemplate"
                  :label="t(appName, 'Template for the default name of the mount point')"
                  :hint="t(appName, '{archiveFileName} will be replaced by the filename of the archive file without extensions.')"
@@ -171,6 +185,8 @@ const settings = reactive({
   humanArchiveSizeLimitAdmin: '',
   mountBackgroundJob: false,
   mountByLeftClick: false,
+  mountDisabled: false,
+  mountDisabledAdmin: false,
   mountPointAutoRename: false,
   mountPointTemplate: '{archiveFileName}',
   mountStripCommonPathPrefixDefault: false,

--- a/src/files-hooks.ts
+++ b/src/files-hooks.ts
@@ -64,31 +64,33 @@ subscribe('notifications:notification:received', (event: NotificationEvent) => {
   }
 });
 
-registerFileAction({
-  id: appName,
-  displayName(_context) {
-    return t(appName, 'Mount Archive');
-  },
-  title(_context: ActionContext) {
-    return t(appName, 'Mount Archive');
-  },
-  iconSvgInline(_context: ActionContext) {
-    return logoSvg;
-  },
-  enabled(context: ActionContext) {
-    if (context.nodes.length !== 1) {
-      return false;
-    }
-    const node = context.nodes[0];
-    if (!(node.permissions & Permission.READ)) {
-      return false;
-    }
-    return node.mime !== undefined && archiveMimeTypes.findIndex((mime) => mime === node.mime) >= 0;
-  },
-  exec: (context) => mount(context.nodes[0], context.view),
-  default: initialState?.mountByLeftClick ? DefaultType.DEFAULT : undefined,
-  order: -1000,
-});
+if (!initialState?.mountDisabled) {
+  registerFileAction({
+    id: appName,
+    displayName(_context) {
+      return t(appName, 'Mount Archive');
+    },
+    title(_context: ActionContext) {
+      return t(appName, 'Mount Archive');
+    },
+    iconSvgInline(_context: ActionContext) {
+      return logoSvg;
+    },
+    enabled(context: ActionContext) {
+      if (context.nodes.length !== 1) {
+        return false;
+      }
+      const node = context.nodes[0];
+      if (!(node.permissions & Permission.READ)) {
+        return false;
+      }
+      return node.mime !== undefined && archiveMimeTypes.findIndex((mime) => mime === node.mime) >= 0;
+    },
+    exec: (context) => mount(context.nodes[0], context.view),
+    default: initialState?.mountByLeftClick ? DefaultType.DEFAULT : undefined,
+    order: -1000,
+  });
+}
 
 registerFileAction({
   id: appName + '-extract',

--- a/src/types/initial-state.d.ts
+++ b/src/types/initial-state.d.ts
@@ -22,6 +22,7 @@ export interface InitialState {
   extractStripCommonPathPrefixDefault: boolean;
   mountBackgroundJob: boolean;
   mountByLeftClick: boolean;
+  mountDisabled: boolean;
   extractBackgroundJob: boolean;
   archiveMimeTypes: string[];
 }

--- a/src/views/FilesTab.vue
+++ b/src/views/FilesTab.vue
@@ -119,7 +119,8 @@
           </NcActionInput>
         </NcActions>
       </li>
-      <li class="files-tab-entry flex flex-center clickable"
+      <li v-if="!archiveMountDisabled || archiveMounted"
+          class="files-tab-entry flex flex-center clickable"
           @click="showArchiveMounts = !showArchiveMounts"
       >
         <div class="files-tab-entry__avatar icon-external-white" />
@@ -137,7 +138,10 @@
           />
         </NcActions>
       </li>
-      <li v-show="showArchiveMounts" class="directory-chooser files-tab-entry">
+      <li v-if="!archiveMountDisabled || archiveMounted"
+          v-show="showArchiveMounts"
+          class="directory-chooser files-tab-entry"
+      >
         <div v-if="loading" class="icon-loading-small" />
         <ul v-else-if="archiveMounted" class="archive-mounts">
           <NcListItem v-for="mountPoint in archiveMounts"
@@ -168,7 +172,7 @@
             </template>
           </NcListItem>
         </ul>
-        <div v-else>
+        <div v-else-if="!archiveMountDisabled">
           <FilePrefixPicker v-model="archiveMountFileInfo"
                             :hint="t(appName, 'Not mounted, create a new mount point:')"
                             :placeholder="t(appName, 'base name')"
@@ -426,6 +430,7 @@ const archiveMountStripCommonPathPrefix = ref(!!initialState?.mountStripCommonPa
 const archiveExtractStripCommonPathPrefix = ref(!!initialState?.extractStripCommonPathPrefixDefault)
 const archiveMountBackgroundJob = ref(!!initialState?.mountBackgroundJob)
 const archiveExtractBackgroundJob = ref(!!initialState?.extractBackgroundJob)
+const archiveMountDisabled = !!initialState?.mountDisabled
 const archivePassPhrase = ref<undefined|string>(undefined)
 
 const showArchiveInfo = ref(true)

--- a/src/views/FilesTab.vue
+++ b/src/views/FilesTab.vue
@@ -118,7 +118,8 @@
           </NcActionInput>
         </NcActions>
       </li>
-      <li class="files-tab-entry flex flex-center clickable"
+      <li v-if="!archiveMountDisabled || archiveMounted"
+          class="files-tab-entry flex flex-center clickable"
           @click="showArchiveMounts = !showArchiveMounts"
       >
         <div class="files-tab-entry__avatar icon-external-white" />
@@ -136,7 +137,10 @@
           />
         </NcActions>
       </li>
-      <li v-show="showArchiveMounts" class="directory-chooser files-tab-entry">
+      <li v-if="!archiveMountDisabled || archiveMounted"
+          v-show="showArchiveMounts"
+          class="directory-chooser files-tab-entry"
+      >
         <div v-if="loading" class="icon-loading-small" />
         <ul v-else-if="archiveMounted" class="archive-mounts">
           <NcListItem v-for="mountPoint in archiveMounts"
@@ -167,7 +171,7 @@
             </template>
           </NcListItem>
         </ul>
-        <div v-else>
+        <div v-else-if="!archiveMountDisabled">
           <FilePrefixPicker v-model="archiveMountFileInfo"
                             :hint="t(appName, 'Not mounted, create a new mount point:')"
                             :placeholder="t(appName, 'base name')"
@@ -426,6 +430,7 @@ const archiveMountStripCommonPathPrefix = ref(!!initialState?.mountStripCommonPa
 const archiveExtractStripCommonPathPrefix = ref(!!initialState?.extractStripCommonPathPrefixDefault)
 const archiveMountBackgroundJob = ref(!!initialState?.mountBackgroundJob)
 const archiveExtractBackgroundJob = ref(!!initialState?.extractBackgroundJob)
+const archiveMountDisabled = !!initialState?.mountDisabled
 const archivePassPhrase = ref<undefined|string>(undefined)
 
 const showArchiveInfo = ref(true)


### PR DESCRIPTION
This is another change from my stable32 testing branch (see #63), ported to `main`.

Mounting an archive as a virtual folder is not always desirable: on some installations the mounts confuse users or other clients, and extraction alone is enough. This adds a new boolean setting `mountDisabled`:

- **Admin setting** ("Archive Mounting" section): disables mounting instance-wide for all users.
- **Personal setting** ("Mount Options" section): lets individual users opt out of mounting for themselves. When the admin switch is on, the personal checkbox is disabled and a hint explains why.

Behaviour when disabled:

- `MountController::mount()` refuses new mounts with a translated error (this also covers scheduled background jobs, which call the same method). Existing mounts stay accessible and can still be unmounted.
- The "Mount Archive" file action is not registered (the "Extract here" action stays available).
- The "Mount Points" section of the details-sidebar tab is hidden, unless existing mounts remain.

The default is unchanged (mounting enabled), so nothing changes for existing installations unless the option is turned on. The read-only `mountDisabledAdmin` mirror in the personal settings follows the existing `archiveSizeLimitAdmin` pattern.

Tested on a NC 33.0.6 docker instance (PHP 8.4): admin/personal round-trips of the setting (default values are not persisted), mount attempts via API return the proper error for both the admin and the personal case, and the Files UI with the option on/off (file-actions menu, sidebar tab, settings pages) shows the expected state with no console errors. `php -l`, eslint on the touched files and a webpack build are clean.