### PR TITLE
Add initial support for Nextcloud 34

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
   <category>files</category>
   <bugs>https://github.com/rotdrop/nextcloud-app-files-archive.git</bugs>
   <dependencies>
-    <nextcloud min-version="33" max-version="33"/>
+    <nextcloud min-version="33" max-version="34"/>
     <php min-version="8.4" max-version="8.5" />
   </dependencies>
   <types>

--- a/lib/Mount/ArchiveMountPoint.php
+++ b/lib/Mount/ArchiveMountPoint.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @author    Claus-Justus Heine <himself@claus-justus-heine.de>
+ * @author    Fabio Fantoni <fabio.fantoni@m2r.biz>
+ * @copyright 2022-2025 Claus-Justus Heine
+ * @copyright 2026 Fabio Fantoni
+ * @license   AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\FilesArchive\Mount;
+
+// F I X M E internal
+use OC\Files\Mount\MountPoint;
+
+use Psr\Log\LoggerInterface;
+
+use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMovableMount;
+use OCP\Files\Config\IUserMountCache;
+use OCP\Files\Storage\IStorageFactory;
+
+use OCA\FilesArchive\Db\ArchiveMount;
+use OCA\FilesArchive\Db\ArchiveMountMapper;
+use OCA\FilesArchive\Service\NotificationService;
+use OCA\FilesArchive\Storage\ArchiveStorage;
+
+/**
+ * Movable mount point wrapping an archive-file storage.
+ */
+class ArchiveMountPoint extends MountPoint implements IMovableMount
+{
+  use \OCA\FilesArchive\Toolkit\Traits\LoggerTrait;
+
+  /**
+   * @param ArchiveStorage $storage
+   *
+   * @param string $mountPointPath
+   *
+   * @param IStorageFactory $loader
+   *
+   * @param string $userFolderPath
+   *
+   * @param IMountManager $mountManager
+   *
+   * @param IUserMountCache $userMountCache
+   *
+   * @param ArchiveMountMapper $mountMapper
+   *
+   * @param ArchiveMount $mountEntity
+   *
+   * @param NotificationService $notificationService
+   *
+   * @param LoggerInterface $logger
+   */
+  public function __construct(
+    ArchiveStorage $storage,
+    string $mountPointPath,
+    IStorageFactory $loader,
+    private string $userFolderPath,
+    private IMountManager $mountManager,
+    private IUserMountCache $userMountCache,
+    private ArchiveMountMapper $mountMapper,
+    private ArchiveMount $mountEntity,
+    private NotificationService $notificationService,
+    protected LoggerInterface $logger,
+  ) {
+    parent::__construct(
+      storage: $storage,
+      mountpoint: $mountPointPath,
+      loader: $loader,
+      mountId: $mountEntity->getArchiveFileId(),
+      mountProvider: MountProvider::class,
+      mountOptions: [
+        'filesystem_check_changes' => 1,
+        'readonly' => true,
+        'previews' => true,
+        'enable_sharing' => false,
+        'authenticated' => false,
+      ],
+    );
+  }
+
+  /** {@inheritdoc} */
+  public function getMountType()
+  {
+    return 'external'; // Constants::APP_NAME;
+  }
+
+  /** {@inheritdoc} */
+  public function moveMount($target)
+  {
+    if (!str_starts_with($target, $this->userFolderPath)) {
+      return false;
+    }
+
+    $relativeTarget = substr($target, strlen($this->userFolderPath));
+
+    // has to be done, the file-cache is then updated automagically, it seems
+    $this->setMountPoint($target);
+
+    $this->mountEntity->setMountPointPath($relativeTarget);
+    $this->mountMapper->update($this->mountEntity);
+
+    // Convenience: obviously the user has realized the mount, so there is
+    // no point in keeping the notification.
+    $this->notificationService->deleteMountSuccessNotification(
+      userId: $this->mountEntity->getUserId(),
+      mountPointId: $this->mountEntity->getMountPointFileId(),
+    );
+
+    return true;
+  }
+
+  /** {@inheritdoc} */
+  public function removeMount()
+  {
+    $this->mountMapper->delete($this->mountEntity);
+    $this->mountManager->removeMount($this->getMountPoint());
+
+    $this->userMountCache->remoteStorageMounts($this->getNumericStorageId());
+
+    // Destroy the cache s.t. we will get a new id on the next mount. This
+    // is necessary to get the display in the front-end correct because
+    // the path cache (Vue "store") does not listen to "deleted" events.
+    /** @var ArchiveStorage $storage */
+    $storage = $this->getStorage();
+    // $storage->getCache()->remove($this->getStorageRootId());
+    // $storage->getStorageCache()->remove($this->getNumericStorageId());
+    $storage->getCache()->clear(); // internal, but much faster
+
+    // Remove the mount-success information in order not to have stale
+    // notifications with links to non-existing files.
+    $this->notificationService->deleteMountSuccessNotification(
+      userId: $this->mountEntity->getUserId(),
+      mountPointId: $this->mountEntity->getMountPointFileId(),
+    );
+
+    return true;
+  }
+}

--- a/lib/Mount/LegacyArchiveMountPoint.php
+++ b/lib/Mount/LegacyArchiveMountPoint.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @author    Fabio Fantoni <fabio.fantoni@m2r.biz>
+ * @copyright 2026 Fabio Fantoni
+ * @license   AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\FilesArchive\Mount;
+
+// F I X M E internal
+use OC\Files\Mount\MoveableMount;
+
+/**
+ * Like ArchiveMountPoint, but additionally implementing the private legacy
+ * MoveableMount interface: Nextcloud < 34 marks a mount point as
+ * movable/removable only through that interface, while Nextcloud >= 34
+ * removed it in favour of the public IMovableMount. This class must only be
+ * loaded when the legacy interface exists.
+ */
+class LegacyArchiveMountPoint extends ArchiveMountPoint implements MoveableMount
+{
+}

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -24,7 +24,6 @@ use Exception;
 use Throwable;
 
 // F I X M E internal
-use OC\Files\Mount\MountPoint;
 use OC\Files\Mount\MoveableMount;
 
 use Psr\Log\LoggerInterface;
@@ -151,13 +150,13 @@ class MountProvider implements IMountProvider
    *
    * @param int $archiveSizeLimit
    *
-   * @return null|MoveableMount
+   * @return null|ArchiveMountPoint
    */
   public function getMountPoint(
     ArchiveMount $mountEntity,
     string $userId,
     int $archiveSizeLimit = Constants::DEFAULT_ADMIN_ARCHIVE_SIZE_LIMIT,
-  ):?MoveableMount {
+  ):?ArchiveMountPoint {
 
     $storageFactory = $this->appContainer->get(IStorageFactory::class);
     $userFolder = $this->rootFolder->getUserFolder($userId);
@@ -183,7 +182,7 @@ class MountProvider implements IMountProvider
    *
    * @param int $archiveSizeLimit
    *
-   * @return null|MoveableMount
+   * @return null|ArchiveMountPoint
    */
   private function doGetMountPoint(
     ArchiveMount $mountEntity,
@@ -191,7 +190,7 @@ class MountProvider implements IMountProvider
     IStorageFactory $loader,
     Folder $userFolder,
     int $archiveSizeLimit = Constants::DEFAULT_ADMIN_ARCHIVE_SIZE_LIMIT,
-  ):?MoveableMount {
+  ):?ArchiveMountPoint {
 
     $userFolderPath = $userFolder->getPath();
 
@@ -226,7 +225,14 @@ class MountProvider implements IMountProvider
       $storage->setRootId($mountEntity->getMountPointFileId());
     }
 
-    return new class(
+    // Nextcloud < 34 marks a mount point as movable/removable only through
+    // the private MoveableMount interface, Nextcloud >= 34 removed it in
+    // favour of the public IMovableMount.
+    $mountPointClass = interface_exists(MoveableMount::class)
+      ? LegacyArchiveMountPoint::class
+      : ArchiveMountPoint::class;
+
+    return new $mountPointClass(
       $storage,
       $mountDirectory,
       $loader,
@@ -237,117 +243,6 @@ class MountProvider implements IMountProvider
       $mountEntity,
       $this->notificationService,
       $this->logger,
-    ) extends MountPoint implements MoveableMount
-    {
-      use \OCA\FilesArchive\Toolkit\Traits\LoggerTrait;
-
-      /**
-       * @param ArchiveStorage $storage
-       *
-       * @param string $mountPointPath
-       *
-       * @param IStorageFactory $loader
-       *
-       * @param string $userFolderPath
-       *
-       * @param IMountManager $mountManager
-       *
-       * @param IUserMountCache $userMountCache
-       *
-       * @param ArchiveMountMapper $mountMapper
-       *
-       * @param ArchiveMount $mountEntity
-       *
-       * @param NotificationService $notificationService
-       *
-       * @param LoggerInterface $logger
-       */
-      public function __construct(
-        ArchiveStorage $storage,
-        string $mountPointPath,
-        IStorageFactory $loader,
-        private string $userFolderPath,
-        private IMountManager $mountManager,
-        private IUserMountCache $userMountCache,
-        private ArchiveMountMapper $mountMapper,
-        private ArchiveMount $mountEntity,
-        private NotificationService $notificationService,
-        protected LoggerInterface $logger,
-      ) {
-        parent::__construct(
-          storage: $storage,
-          mountpoint: $mountPointPath,
-          loader: $loader,
-          mountId: $mountEntity->getArchiveFileId(),
-          mountProvider: MountProvider::class,
-          mountOptions: [
-            'filesystem_check_changes' => 1,
-            'readonly' => true,
-            'previews' => true,
-            'enable_sharing' => false,
-            'authenticated' => false,
-          ],
-        );
-      }
-
-      /** {@inheritdoc} */
-      public function getMountType()
-      {
-        return 'external'; // Constants::APP_NAME;
-      }
-
-      /** {@inheritdoc} */
-      public function moveMount($target)
-      {
-        if (!str_starts_with($target, $this->userFolderPath)) {
-          return false;
-        }
-
-        $relativeTarget = substr($target, strlen($this->userFolderPath));
-
-        // has to be done, the file-cache is then updated automagically, it seems
-        $this->setMountPoint($target);
-
-        $this->mountEntity->setMountPointPath($relativeTarget);
-        $this->mountMapper->update($this->mountEntity);
-
-        // Convenience: obviously the user has realized the mount, so there is
-        // no point in keeping the notification.
-        $this->notificationService->deleteMountSuccessNotification(
-          userId: $this->mountEntity->getUserId(),
-          mountPointId: $this->mountEntity->getMountPointFileId(),
-        );
-
-        return true;
-      }
-
-      /** {@inheritdoc} */
-      public function removeMount()
-      {
-        /** @var MountPoint $this */
-        $this->mountMapper->delete($this->mountEntity);
-        $this->mountManager->removeMount($this->getMountPoint());
-
-        $this->userMountCache->remoteStorageMounts($this->getNumericStorageId());
-
-        // Destroy the cache s.t. we will get a new id on the next mount. This
-        // is necessary to get the display in the front-end correct because
-        // the path cache (Vue "store") does not listen to "deleted" events.
-        /** @var ArchiveStorage $storage */
-        $storage = $this->getStorage();
-        // $storage->getCache()->remove($this->getStorageRootId());
-        // $storage->getStorageCache()->remove($this->getNumericStorageId());
-        $storage->getCache()->clear(); // internal, but much faster
-
-        // Remove the mount-success information in order not to have stale
-        // notifications with links to non-existing files.
-        $this->notificationService->deleteMountSuccessNotification(
-          userId: $this->mountEntity->getUserId(),
-          mountPointId: $this->mountEntity->getMountPointFileId(),
-        );
-
-        return true;
-      }
-    };
+    );
   }
 }


### PR DESCRIPTION
Closes #72.

Nextcloud 34 removed the private `OC\Files\Mount\MoveableMount` interface in favour of the public `OCP\Files\Mount\IMovableMount` (nextcloud/server commit fbf84e64732, "chore: Replace MoveableMount usage with IMovableMount"), so the anonymous mount-point class in `MountProvider` fails to instantiate on Nextcloud 34. As far as I could check (all `OCP\*` and `OC\*` classes/methods used by the app and by the toolkit, diffed between `stable33` and `stable34`), this is the only API used by the app which was removed or changed incompatibly in Nextcloud 34.

Simply switching to `IMovableMount` would break Nextcloud 33, though: up to Nextcloud 33 the server marks a mount point as movable/removable only through the private `MoveableMount` interface (`View::moveMount()` even throws `ForbiddenException` "Storage cannot be moved" otherwise), while the public `IMovableMount` (which `MoveableMount` extends) is mostly ignored there. Only Nextcloud >= 34 checks the public interface.

So this PR:

- extracts the anonymous mount-point class from `MountProvider` into the named class `ArchiveMountPoint` (unchanged body), implementing the public `IMovableMount`;
- adds a `LegacyArchiveMountPoint` subclass which additionally implements the legacy private `MoveableMount`; `MountProvider` instantiates it when that interface (still) exists, i.e. on Nextcloud <= 33, so the legacy class is never even autoloaded on Nextcloud >= 34;
- bumps the supported Nextcloud range to 33-34.

Tested against Nextcloud 34.0.2 RC1 and re-tested against 33.0.6 (SQLite dev instances): mounting, browsing and reading mounted archives, moving/renaming and deleting the mount folder (with the DB record following along), archive extraction, admin and personal settings pages, the "Register MIME types" repair step, and the "Mount Archive" / "Extract here" file actions in the web UI.

One unrelated note from testing: renaming or deleting an archive *file* while it is mounted leaves a stale mount record behind (`FileNodeListener` dies on a `NotFoundException` from `$sourceNode->getType()`). This is *not* a Nextcloud 34 regression — it behaves identically on 33 — so it is left out of this PR; I opened [an issue](https://github.com/rotdrop/nextcloud-app-files-archive/issues/74) related.