### PR TITLE
Register archive MIME types without writing the mapping override file

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -71,6 +71,13 @@ class Application extends App implements IBootstrap
     $context->injectFn(function(IMountProviderCollection $mountProviderCollection, ArchiveMountProvider $mountProvider) {
       $mountProviderCollection->registerProvider($mountProvider, PHP_INT_MAX - 1);
     });
+
+    // Make the archive extension to MIME-type mappings known to the MIME-type
+    // detector for every request, so that newly uploaded archives are detected
+    // correctly without having to persist anything into config/.
+    $context->injectFn(function(MimeTypeService $mimeTypeService) {
+      $mimeTypeService->registerMimeTypeMappings();
+    });
   }
 
   /**

--- a/lib/Migration/RegisterMimeTypes.php
+++ b/lib/Migration/RegisterMimeTypes.php
@@ -20,8 +20,8 @@
 
 namespace OCA\FilesArchive\Migration;
 
-use Throwable;
-
+use OCP\Files\IMimeTypeDetector;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Psr\Log\LoggerInterface as ILogger;
@@ -29,17 +29,29 @@ use Psr\Log\LoggerInterface as ILogger;
 use OCA\FilesArchive\Service\MimeTypeService;
 
 /**
- * Register some extra mime-types, in particuluar in order to have custom
- * folder icons for the database storage. Nextcloud uses the `dir-MOUNTTYPE`
- * pseudo mime-type in order to select icons for directories.
+ * Make the archive MIME-types known to this Nextcloud instance.
  *
- * @see OCA\CAFEVDB\Storage\Database\MountProvider
+ * The extension to MIME-type mappings themselves are registered at runtime
+ * with the MIME-type detector during the app bootstrap (see
+ * \OCA\FilesArchive\AppInfo\Application and
+ * \OCA\FilesArchive\Toolkit\Service\MimeTypeService::registerMimeTypeMappings()).
+ * This repair step takes care of the two things which cannot be done at
+ * runtime per request:
+ *
+ * - persist the MIME-types in the database and fix the `filecache` rows of
+ *   already existing archive files (the same work as
+ *   `occ maintenance:mimetype:update-db`), using only public API;
+ *
+ * - register icon aliases (every archive type should use the `package/x-generic`
+ *   icon) for the archive MIME-types which the core does not know about yet.
+ *   Aliases have no runtime-registration API, so this is the only situation in
+ *   which we touch the instance configuration -- and only when something is
+ *   actually missing and the configuration is writable.
  */
 class RegisterMimeTypes implements IRepairStep
 {
   use \OCA\FilesArchive\Toolkit\Traits\LoggerTrait;
 
-  const MIMETYPE_MAPPING_FILE = 'mimetypemapping.json';
   const MIMETYPE_ALIASES_FILE = 'mimetypealiases.json';
 
   // phpcs:disable Squiz.Commenting.FunctionComment.Missing
@@ -47,6 +59,8 @@ class RegisterMimeTypes implements IRepairStep
     protected string $appName,
     protected ILogger $logger,
     protected MimeTypeService $mimeTypeService,
+    protected IMimeTypeDetector $mimeTypeDetector,
+    protected IMimeTypeLoader $mimeTypeLoader,
   ) {
   }
   // phpcs:enable
@@ -60,58 +74,114 @@ class RegisterMimeTypes implements IRepairStep
   /** {@inheritdoc} */
   public function run(IOutput $output)
   {
-    $mimeData = [
-      'mapping' => [
-        'core' => \OC::$configDir . self::MIMETYPE_MAPPING_FILE,
-        'app' => __DIR__ . '/../../config/nextcloud/' . self::MIMETYPE_MAPPING_FILE,
-      ],
-      'aliases' => [
-        'core' => \OC::$configDir . self::MIMETYPE_ALIASES_FILE,
-        'app' => __DIR__ . '/../../config/nextcloud/' . self::MIMETYPE_ALIASES_FILE,
-      ],
-    ];
+    // getSupportedArchiveMimeTypes() also registers our extension to
+    // MIME-type mappings with the detector for the current process, so that
+    // the database update below sees them when running via occ.
+    $archiveMimeTypes = $this->mimeTypeService->getSupportedArchiveMimeTypes();
 
-    foreach ($mimeData as $key => $dataSet) {
-      $coreFile = $dataSet['core'];
+    $this->updateDatabaseMimeTypes($output, $archiveMimeTypes);
+    $this->registerMissingAliases($output);
 
-      if (!is_writable($coreFile)) {
-        $this->logError('Unable to update "' . $coreFile . '", file is not writable.');
-        continue;
-      } else {
-        $this->logInfo('Modifying "' . $coreFile . '" ...');
-      }
-
-      switch ($key) {
-        case 'aliases':
-          try {
-            $appFile = $dataSet['app'];
-            if (file_exists($appFile)) {
-              $appData = json_decode(file_get_contents($appFile), true);
-            } else {
-              $appData = [];
-            }
-          } catch (Throwable $t) {
-            $this->logException($t);
-            continue 2;
-          }
-          break;
-        case 'mapping':
-          $appData = $this->mimeTypeService->getMissingMimeTypeMappings();
-          break;
-      }
-
-      if (file_exists($coreFile)) {
-        $coreData = json_decode(file_get_contents($coreFile), true);
-        $data = array_merge($coreData, $appData);
-      }
-      file_put_contents($coreFile, json_encode($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
-      $this->logInfo('... added mime-data ' . print_r($dataSet['app'], true));
-    }
-
-    // @todo Check whether `occ maintenance:mimetype:update-js` and/or `occ
-    // maintenance:mimetype:update-db` must be run. This should be automated.
-    //
     // @todo Implement a mime-type cleanup on uninstall (not sooo important
     // but should be done one day).
+  }
+
+  /**
+   * Make sure the archive MIME-types exist in the database and fix the
+   * `filecache` rows of already existing archive files. This mirrors
+   * `occ maintenance:mimetype:update-db` but is restricted to our own
+   * MIME-types and only touches the filecache for newly added ones.
+   *
+   * @param IOutput $output
+   *
+   * @param array<string, string> $archiveMimeTypes Extension to MIME-type map.
+   *
+   * @return void
+   */
+  protected function updateDatabaseMimeTypes(IOutput $output, array $archiveMimeTypes):void
+  {
+    // Snapshot which MIME-types already exist before we add anything, so that
+    // multiple extensions sharing a freshly added MIME-type all get their
+    // filecache rows updated.
+    $existedBefore = [];
+    foreach ($archiveMimeTypes as $mimeType) {
+      if (!array_key_exists($mimeType, $existedBefore)) {
+        $existedBefore[$mimeType] = $this->mimeTypeLoader->exists($mimeType);
+      }
+    }
+
+    foreach ($archiveMimeTypes as $extension => $mimeType) {
+      // getId() inserts the MIME-type if it is not present yet.
+      $mimeTypeId = $this->mimeTypeLoader->getId($mimeType);
+      if ($existedBefore[$mimeType]) {
+        continue;
+      }
+      $touched = $this->mimeTypeLoader->updateFilecache((string)$extension, $mimeTypeId);
+      $this->logInfo('Registered archive MIME-type "' . $mimeType . '" (.' . $extension . '), updated ' . $touched . ' filecache rows.');
+    }
+  }
+
+  /**
+   * Register the icon aliases for the archive MIME-types which the core does
+   * not know about. Aliases cannot be registered at runtime, so they have to
+   * live in the instance configuration. We only write the configuration when
+   * something is actually missing -- the comparison is done against the
+   * effective alias set, which already folds in any pre-existing custom
+   * `config/mimetypealiases.json`, so a file written by an admin or an earlier
+   * run is respected and never clobbered.
+   *
+   * @param IOutput $output
+   *
+   * @return void
+   */
+  protected function registerMissingAliases(IOutput $output):void
+  {
+    $appFile = __DIR__ . '/../../config/nextcloud/' . self::MIMETYPE_ALIASES_FILE;
+    if (!file_exists($appFile)) {
+      return;
+    }
+    $appAliases = json_decode(file_get_contents($appFile), true) ?? [];
+    $appAliases = array_filter(
+      $appAliases,
+      fn(string $key) => !str_starts_with($key, '_'),
+      ARRAY_FILTER_USE_KEY,
+    );
+
+    // getAllAliases() == dist aliases + any existing config/mimetypealiases.json.
+    $effectiveAliases = $this->mimeTypeDetector->getAllAliases();
+    $missingAliases = array_diff_key($appAliases, $effectiveAliases);
+    if (empty($missingAliases)) {
+      // Everything is already aliased (by the core or by an existing override),
+      // so there is no reason to touch the configuration.
+      return;
+    }
+
+    $coreFile = \OC::$configDir . self::MIMETYPE_ALIASES_FILE;
+
+    // Nextcloud only ships *.dist.json in resources/config/; the override in
+    // config/ usually does not exist yet, so probe the directory rather than
+    // is_writable() of a non-existing path.
+    if (file_exists($coreFile)) {
+      if (!is_writable($coreFile)) {
+        $this->logWarn('Cannot add archive icon aliases: "' . $coreFile . '" is not writable. Unknown archive types will use the generic file icon.');
+        return;
+      }
+      $existing = json_decode(file_get_contents($coreFile), true) ?? [];
+    } elseif (is_writable(dirname($coreFile))) {
+      $existing = [];
+    } else {
+      $this->logWarn('Cannot add archive icon aliases: "' . dirname($coreFile) . '" is not writable. Unknown archive types will use the generic file icon.');
+      return;
+    }
+
+    $merged = array_merge($existing, $missingAliases);
+    if ($merged == $existing) {
+      return;
+    }
+
+    file_put_contents($coreFile, json_encode($merged, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+    $message = 'Added archive icon aliases to "' . $coreFile . '". Run "occ maintenance:mimetype:update-js" to refresh the web UI icons.';
+    $this->logInfo($message);
+    $output->info($message);
   }
 }


### PR DESCRIPTION
This is another change from my stable32 testing branch (see #63), ported to `main`.

The `RegisterMimeTypes` repair step is currently a no-op on a fresh instance, and used to crash on some of them. It assumes that `config/mimetypemapping.json` and `config/mimetypealiases.json` already exist, but Nextcloud only ships the `*.dist.json` defaults under `resources/config/` and never creates the overrides. `is_writable()` on the non-existing path returns false, so the step logs "file is not writable" and skips everything; if the file is then created empty as a workaround, `json_decode()` returns null and `array_merge(null, ...)` throws a TypeError.

There is no app-facing API to register MIME types (`IRegistrationContext` has none), which is why apps that only register file actions or viewers work against MIME types the core already knows and never touch those files. `files_archive` is different: it introduces extensions the core does not know (arj, cab, dmg, iso, rpm, xz, tar.gz composites, ...), so the detector genuinely has to learn about them.

The change reworks this along three layers instead of rewriting the override files:

- **Detection** is registered at boot, via `MimeTypeService::registerMimeTypeMappings()` in `Application::boot()`. Every request (web, occ, WebDAV) detects archives correctly in memory, and nothing is persisted into `config/`.
- **Existing files** are handled by the repair step through the public `IMimeTypeLoader` API (`exists`/`getId`/`updateFilecache`, the same work as `occ maintenance:mimetype:update-db`), so the `mimetypemapping.json` override is not written at all any more. `updateFilecache()` is public API since 32.0.0, so this works on every version `main` supports.
- **Icon aliases** are the only thing without a runtime API, so they still live in `config/mimetypealiases.json` — but the file is written only when an alias is actually missing from the effective alias set (`IMimeTypeDetector::getAllAliases()`, which already folds in an existing custom file). The step is therefore idempotent and non-destructive: an admin's own file is merged, never clobbered, and left untouched when nothing is missing. If `config/` is not writable the step degrades to a warning (generic icon) instead of throwing, and `maintenance:mimetype:update-js` is not run automatically (it writes into the read-only server root); the admin is pointed at it instead.

This should also address a good part of the complaint in #49: the alias file is no longer rewritten on every repair run, existing entries are preserved, and only genuinely missing archive aliases are added.

## Testing

Tested on docker dev instances of NC 33.0.6 (PHP 8.4) and NC 34.0.2, both with no `config/mimetypemapping.json` and no `config/mimetypealiases.json`, i.e. the state of a normal installation.

Before (current `main`), on both versions: `occ maintenance:repair` logs `Unable to update "/var/www/html/config/mimetypemapping.json", file is not writable` (and the same for the aliases), nothing is registered, and archives uploaded over WebDAV end up in the file cache as

```
test-archive.tar.gz => application/gzip
test-archive.tar.xz => application/octet-stream
test-fake.cab       => application/octet-stream
test-fake.iso       => application/octet-stream
test-fake.rpm       => application/octet-stream
```

After the change, on both versions:

- `occ maintenance:repair` reports `Added archive icon aliases to ".../config/mimetypealiases.json". Run "occ maintenance:mimetype:update-js" to refresh the web UI icons.`, the archive MIME types are inserted into the database, and the file-cache rows of the already uploaded files are fixed:

```
test-archive.tar.gz => application/x-gzip
test-archive.tar.xz => application/x-xz
test-fake.cab       => application/vnd.ms-cab-compressed
test-fake.iso       => application/x-iso9660-image
test-fake.rpm       => application/x-rpm
```

- Only the 10 aliases actually missing from the core defaults are written; `mimetypemapping.json` is never created.
- Running the repair step again produces no output and does not rewrite the file (same mtime, same size).
- Non-destructive merge: after manually adding an unrelated `"application/x-my-custom": "dir"` entry and removing `application/x-rpm` from the file, the next run re-adds only `application/x-rpm` and keeps the custom entry.
- Boot-time detection: a `.dmg` upload (a type the archive backend does not support, so the repair step does not add it) is stored as `application/x-apple-diskimage` right away, without any repair run.
- No regression in the app itself: `archive/info` and `archive/extract` work as before, and `.tar.gz` is now reported as `application/x-gzip` / format `tgz` instead of the generic gzip type.

`php -l` and `phpcs` are clean on the touched files (only the pre-existing TODO warning).