### PR TITLE
Add admin defaults for the strip-common-path-prefix options

### DIFF
--- a/lib/Controller/ArchiveController.php
+++ b/lib/Controller/ArchiveController.php
@@ -113,8 +113,14 @@ class ArchiveController extends Controller
     $this->autoRenameExtractTarget = (bool)$cloudConfig->getUserValue(
       $this->userId, $this->appName, SettingsController::EXTRACT_TARGET_AUTO_RENAME, false);
 
+    $stripCommonPathPrefixDefault = (bool)$cloudConfig->getAppValue(
+      $this->appName,
+      SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+      SettingsController::STRIP_COMMON_PATH_PREFIX_DEFAULT);
+
     $this->stripCommonPathPrefixDefault = (bool)$cloudConfig->getUserValue(
-      $this->userId, $this->appName, SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT, false);
+      $this->userId, $this->appName, SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+      $stripCommonPathPrefixDefault);
   }
   // phpcs:enable
 

--- a/lib/Controller/MountController.php
+++ b/lib/Controller/MountController.php
@@ -119,8 +119,14 @@ class MountController extends Controller
       $this->autoRenameMountPoint = (bool)$cloudConfig->getUserValue(
         $this->userId, $this->appName, SettingsController::MOUNT_POINT_AUTO_RENAME, false);
 
+      $stripCommonPathPrefixDefault = (bool)$cloudConfig->getAppValue(
+        $this->appName,
+        SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+        SettingsController::STRIP_COMMON_PATH_PREFIX_DEFAULT);
+
       $this->stripCommonPathPrefixDefault = (bool)$cloudConfig->getUserValue(
-        $this->userId, $this->appName, SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT, false);
+        $this->userId, $this->appName, SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+        $stripCommonPathPrefixDefault);
 
       $mountDisabledDefault = (bool)$cloudConfig->getAppValue(
         $this->appName, SettingsController::MOUNT_DISABLED, SettingsController::MOUNT_DISABLED_DEFAULT);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -61,11 +61,23 @@ class SettingsController extends Controller
   const ADMIN_SETTINGS = [
     self::ARCHIVE_SIZE_LIMIT => [ 'rw' => true, 'default' => self::DEFAULT_ADMIN_ARCHIVE_SIZE_LIMIT ],
     self::MOUNT_DISABLED => [ 'rw' => true, 'default' => self::MOUNT_DISABLED_DEFAULT ],
+    self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT => [
+      'rw' => true, 'default' => self::STRIP_COMMON_PATH_PREFIX_DEFAULT,
+    ],
+    self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT => [
+      'rw' => true, 'default' => self::STRIP_COMMON_PATH_PREFIX_DEFAULT,
+    ],
   ];
 
+  public const STRIP_COMMON_PATH_PREFIX_DEFAULT = false;
+
   public const MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT = 'mountStripCommonPathPrefixDefault';
+  public const MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT_ADMIN =
+    self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT . self::ADMIN_SETTING;
 
   public const EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT = 'extractStripCommonPathPrefixDefault';
+  public const EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT_ADMIN =
+    self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT . self::ADMIN_SETTING;
 
   public const MOUNT_POINT_AUTO_RENAME = 'mountPointAutoRename';
 
@@ -100,8 +112,18 @@ class SettingsController extends Controller
   const PERSONAL_SETTINGS = [
     self::ARCHIVE_SIZE_LIMIT => [ 'rw' => true, ],
     self::ARCHIVE_SIZE_LIMIT_ADMIN => [ 'rw' => false, 'default' => self::DEFAULT_ADMIN_ARCHIVE_SIZE_LIMIT ],
-    self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT => [ 'rw' => true, 'default' => false, ],
-    self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT => [ 'rw' => true, 'default' => false, ],
+    self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT => [
+      'rw' => true, 'default' => self::STRIP_COMMON_PATH_PREFIX_DEFAULT,
+    ],
+    self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT_ADMIN => [
+      'rw' => false, 'default' => self::STRIP_COMMON_PATH_PREFIX_DEFAULT,
+    ],
+    self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT => [
+      'rw' => true, 'default' => self::STRIP_COMMON_PATH_PREFIX_DEFAULT,
+    ],
+    self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT_ADMIN => [
+      'rw' => false, 'default' => self::STRIP_COMMON_PATH_PREFIX_DEFAULT,
+    ],
     self::MOUNT_POINT_AUTO_RENAME => [ 'rw' => true, 'default' => false, ],
     self::EXTRACT_TARGET_AUTO_RENAME => [ 'rw' => true, 'default' => false, ],
     self::MOUNT_POINT_TEMPLATE => [ 'rw' => true, 'default' => self::FOLDER_TEMPLATE_DEFAULT ],
@@ -162,7 +184,9 @@ class SettingsController extends Controller
           return self::grumble($t->getMessage());
         }
         break;
+      case self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
       case self::MOUNT_DISABLED:
+      case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
         $newValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]);
         if ($newValue === null) {
           return self::grumble(
@@ -245,7 +269,9 @@ class SettingsController extends Controller
             $humanValue = '';
           }
           break;
+        case self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
         case self::MOUNT_DISABLED:
+        case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
           $value = (bool)$value;
           $humanValue = $value;
           break;
@@ -299,12 +325,10 @@ class SettingsController extends Controller
         }
         break;
       case self::EXTRACT_BACKGROUND_JOB:
-      case self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
       case self::EXTRACT_TARGET_AUTO_RENAME:
       case self::MOUNT_BACKGROUND_JOB:
       case self::MOUNT_BY_LEFT_CLICK:
       case self::MOUNT_POINT_AUTO_RENAME:
-      case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
         $oldValue = filter_var($oldValue, FILTER_VALIDATE_BOOLEAN);
         $newValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]);
         if ($newValue === null) {
@@ -317,9 +341,12 @@ class SettingsController extends Controller
           $newValue = null;
         }
         break;
+      case self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
       case self::MOUNT_DISABLED:
+      case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
         $oldValue = filter_var(
-          $this->config->getUserValue($this->userId, $this->appName, $setting, $this->mountDisabledDefault()),
+          $this->config->getUserValue(
+            $this->userId, $this->appName, $setting, $this->administrativeDefault($setting)),
           FILTER_VALIDATE_BOOLEAN);
         $newValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]);
         if ($newValue === null) {
@@ -420,12 +447,15 @@ class SettingsController extends Controller
           $adminKey,
           self::ADMIN_SETTINGS[$adminKey]['default'] ?? null,
         );
-      } elseif ($oneSetting === self::MOUNT_DISABLED) {
+      } elseif ($oneSetting === self::MOUNT_DISABLED
+                || $oneSetting === self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT
+                || $oneSetting === self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT) {
+        // the administrative value is only the default for the personal one
         $value = $this->config->getUserValue(
           $this->userId,
           $this->appName,
           $oneSetting,
-          $this->mountDisabledDefault());
+          $this->administrativeDefault($oneSetting));
       } else {
         $value = $this->config->getUserValue(
           $this->userId,
@@ -450,6 +480,7 @@ class SettingsController extends Controller
           break;
         case self::EXTRACT_BACKGROUND_JOB:
         case self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
+        case self::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT_ADMIN:
         case self::EXTRACT_TARGET_AUTO_RENAME:
         case self::MOUNT_BACKGROUND_JOB:
         case self::MOUNT_BY_LEFT_CLICK:
@@ -457,6 +488,7 @@ class SettingsController extends Controller
         case self::MOUNT_DISABLED_ADMIN:
         case self::MOUNT_POINT_AUTO_RENAME:
         case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT:
+        case self::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT_ADMIN:
           $value = !!$value;
           break;
         default:
@@ -477,15 +509,18 @@ class SettingsController extends Controller
   }
 
   /**
-   * The administrative setting for the mount-disabled switch only defines the
-   * default for the users, who may override it in both directions.
+   * The administrative settings which also exist as personal settings only
+   * define the instance-wide default, the users may override them in both
+   * directions.
+   *
+   * @param string $setting
    *
    * @return bool
    */
-  private function mountDisabledDefault(): bool
+  private function administrativeDefault(string $setting): bool
   {
     return (bool)$this->config->getAppValue(
-      $this->appName, self::MOUNT_DISABLED, self::MOUNT_DISABLED_DEFAULT);
+      $this->appName, $setting, self::ADMIN_SETTINGS[$setting]['default'] ?? false);
   }
 
   /**

--- a/lib/Listener/FilesActionListener.php
+++ b/lib/Listener/FilesActionListener.php
@@ -138,10 +138,20 @@ class FilesActionListener implements IEventListener
         'adminContact' => $this->getCloudAdminContacts(implode: true),
         'phpUserAgent' => $_SERVER['HTTP_USER_AGENT'], // @@todo get in javascript from request
         'archiveMimeTypes' => $archiveMimeTypes,
-        SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT => $cloudConfig->getUserValue(
-          $userId, $appName, SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT, false),
-        SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT => $cloudConfig->getUserValue(
-          $userId, $appName, SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT, false),
+        SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT => filter_var(
+          $cloudConfig->getUserValue(
+            $userId, $appName, SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+            $cloudConfig->getAppValue(
+              $appName, SettingsController::MOUNT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+              SettingsController::STRIP_COMMON_PATH_PREFIX_DEFAULT)),
+          FILTER_VALIDATE_BOOLEAN),
+        SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT => filter_var(
+          $cloudConfig->getUserValue(
+            $userId, $appName, SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+            $cloudConfig->getAppValue(
+              $appName, SettingsController::EXTRACT_STRIP_COMMON_PATH_PREFIX_DEFAULT,
+              SettingsController::STRIP_COMMON_PATH_PREFIX_DEFAULT)),
+          FILTER_VALIDATE_BOOLEAN),
         SettingsController::MOUNT_BACKGROUND_JOB => $cloudConfig->getUserValue(
           $userId, $appName, SettingsController::MOUNT_BACKGROUND_JOB, SettingsController::MOUNT_BACKGROUND_JOB_DEFAULT),
         SettingsController::EXTRACT_BACKGROUND_JOB => $cloudConfig->getUserValue(

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -30,6 +30,21 @@
                  :disabled="loading"
                  @submit="saveTextInput('archiveSizeLimit', settings.humanArchiveSizeLimit)"
       />
+      <div class="settings-option">
+        <input id="files-archive-admin-extract-strip-common-prefix"
+               v-model="settings.extractStripCommonPathPrefixDefault"
+               type="checkbox"
+               class="checkbox"
+               :disabled="loading"
+               @change="saveSetting('extractStripCommonPathPrefixDefault')"
+        >
+        <label for="files-archive-admin-extract-strip-common-prefix">
+          {{ t(appName, 'strip common path prefix by default') }}
+        </label>
+      </div>
+      <span class="hint">
+        {{ t(appName, 'This only defines the default for all users, everybody may override it in the personal settings.') }}
+      </span>
     </NcSettingsSection>
     <NcSettingsSection :name="t(appName, 'Archive Mounting')">
       <div class="settings-option">
@@ -42,6 +57,18 @@
         >
         <label for="files-archive-admin-mount-disabled">
           {{ t(appName, 'disable mounting of archive files by default') }}
+        </label>
+      </div>
+      <div class="settings-option">
+        <input id="files-archive-admin-mount-strip-common-prefix"
+               v-model="settings.mountStripCommonPathPrefixDefault"
+               type="checkbox"
+               class="checkbox"
+               :disabled="loading"
+               @change="saveSetting('mountStripCommonPathPrefixDefault')"
+        >
+        <label for="files-archive-admin-mount-strip-common-prefix">
+          {{ t(appName, 'strip common path prefix by default') }}
         </label>
       </div>
       <span class="hint">
@@ -89,6 +116,8 @@ const settings = reactive({
   archiveSizeLimit: 0x100000000,
   humanArchiveSizeLimit: '',
   mountDisabled: false,
+  mountStripCommonPathPrefixDefault: false,
+  extractStripCommonPathPrefixDefault: false,
 })
 
 const diagnostics = reactive({


### PR DESCRIPTION
Another change from my stable32 testing branch (see #63), ported to `main` and reworked to follow the semantics we settled on in #70.

The "strip common path prefix by default" options for mounting and extracting archives are personal settings with a hard-coded default of `false`. On instances where archives usually carry a single top-level directory, every user has to find and flip both switches. This adds them as administrative settings which provide the instance-wide default, while each user can still override that default in either direction in the personal settings — exactly like `mountDisabled`.

- `ADMIN_SETTINGS` gains both keys, `setAdmin()`/`getAdmin()` handle them as booleans, and the admin page gets one checkbox in the "Archive Extraction" section and one in "Archive Mounting", both covered by the existing "This only defines the default for all users, everybody may override it in the personal settings." hint.
- A personal value is **always recorded**, even when it happens to match the current administrative default. This is the point that came up in #70: if the key were dropped when it equals the default, an explicit personal choice would silently follow a later change of the administrative default.
- `MountController`, `ArchiveController` and `FilesActionListener` resolve the value as personal → administrative → `false`, so an explicit request parameter still wins over both.
- The private `mountDisabledDefault()` helper is generalized to `administrativeDefault(string $setting)` and now serves all three switches.
- The settings endpoints and the initial state emit real booleans. An explicit personal "off" override is stored as `"0"`, which is truthy in JavaScript: `InitialState` declares these two members as `boolean`, but the listener passed the raw string through, so the file actions would have stripped the prefix against the user's explicit choice.

## Testing

Tested on docker dev instances of NC 33.0.6 (PHP 8.4) and NC 34.0.2, with identical results on both.

- Administrative switch on, user who never touched the option: `GET /settings/personal` reports `true` for both options and no user key exists in the database.
- User picks the same value as the administrative default: the personal key **is** written (`oc_preferences` row with value `1`, boolean type). Turning the administrative default back off leaves that user at `true`, which is the behaviour asked for in #70.
- User overrides to "off" while the administrative default is on: the row is stored as `0`, the effective value is `false` and extraction keeps the common prefix (`prefix/top/dir/a.txt`), while the same archive extracted by a user without an override lands as `prefix/a.txt`.
- Initial state: with the personal override set to "off" the old code emitted the string `'0'` (truthy in JS) and dropped the administrative default; the new code emits `false` and `true` respectively.
- Admin UI checked with a headless browser on NC 33: both new checkboxes render with the right state, and toggling one stores it (`POST .../settings/admin/extractStripCommonPathPrefixDefault` → 200, `newValue: false`).
- `php -l` and `phpcs` are clean on the touched files (only the pre-existing TODO warning in `FilesActionListener`), and `npm run dev` (webpack + eslint) compiles without errors.

## Unrelated observation

While testing the admin page I noticed that `getDriversStatus()` in `AdminSettings.vue` checks `if (!diagnostics.formats)` instead of `diagnostics.drivers`, so it logs a spurious "UNEXPECTED RESPONSE" when the drivers request finishes before the formats one. Both endpoints answer correctly; I left it alone since it is unrelated to this PR.