### PR TITLE
AdminSettings: check the right diagnostics field after loading the drivers

### DIFF
--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -141,7 +141,7 @@ async function getDriversStatus() {
   try {
     const response = await axios.get(generateAppUrl('diagnostics/archive/drivers'))
     diagnostics.drivers = response?.data?.html || null
-    if (!diagnostics.formats) {
+    if (!diagnostics.drivers) {
       logger.error('UNEXPECTED RESPONSE', response)
     }
     return


### PR DESCRIPTION
Noticed while testing the admin page for another change.

`getDriversStatus()` stores the driver table in `diagnostics.drivers`, but the emptiness check right below it tests `diagnostics.formats`, which is filled by the concurrent `getFormatsMatrix()` request. The two requests are fired one after the other without awaiting each other, so whenever the drivers response arrives first the check sees an empty value and logs a spurious `UNEXPECTED RESPONSE` error. The other way round, an actually empty driver table is never reported.

One character of a fix: check `diagnostics.drivers`.

## Testing

NC 33.0.6 dev instance, admin settings page of the app loaded five times in a headless browser: both diagnostics blocks render (format matrix and driver table) and the console stays clean. Before the change the same page reliably produced `FilesArchive UNEXPECTED RESPONSE {data: Object, status: 200, ...}` on the runs where the drivers request won the race, even though both endpoints answered 200 with a non-empty `html` payload.